### PR TITLE
feat(TimePicker): Pass through disabled prop

### DIFF
--- a/src/FormComponents/FormTimePicker.vue
+++ b/src/FormComponents/FormTimePicker.vue
@@ -15,6 +15,7 @@
                     :disable-date="true"
                     :no-header="true"
                     :minute-interval="timePickerInterval"
+                    :disabled="disabled"
                 ></vue-ctk-date-time-picker>
             </div>
             <div v-if="hasHelpText">

--- a/src/FormComponents/FormTimePicker.vue
+++ b/src/FormComponents/FormTimePicker.vue
@@ -15,7 +15,7 @@
                     :disable-date="true"
                     :no-header="true"
                     :minute-interval="timePickerInterval"
-                    :disabled="disabled"
+                    :disabled="!!disabled"
                 ></vue-ctk-date-time-picker>
             </div>
             <div v-if="hasHelpText">


### PR DESCRIPTION
Simply allow the disabled prop to be passed down to the component call. Prop is passed via the FormField mixin.